### PR TITLE
Use MessageContent instead of custom parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = class InAppNotifciations extends Plugin {
                         isEdited: () => false,
                         hasFlag: () => false // somehow having theese be functions that return false makes discord not crash????????????
                       },
-                      content: parser(args[1].content)
+                      content: parser(args[1].content, true, { channelId: args[0].id })
                     }),
                     buttons: [ {
                         text: `Jump to ${guild ? `#${args[0].name}` : "Direct Messages"}`,

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-const { getModule } = require("powercord/webpack");
+const { getModule, React } = require("powercord/webpack");
 const { inject, uninject } = require("powercord/injector");
 const { Plugin } = require("powercord/entities");
-
-const getUser = getModule(["getCurrentUser"], false).getUser;
-const getChannel = getModule(["getChannel"], false).getChannel;
-const getGuild = getModule(["getGuild"], false).getGuild;
-
+const { getGuild } = getModule(["getGuild"], false);
+const parser = getModule(["parse", "parseTopic"], false).parse;
+const MessageContent = getModule(m => m.type && m.type.displayName == "MessageContent", false);
 const Settings = require("./Settings");
 
 module.exports = class InAppNotifciations extends Plugin {
@@ -33,7 +31,14 @@ module.exports = class InAppNotifciations extends Plugin {
                 powercord.api.notices.sendToast(toast, {
                     header: guild ? `${args[2].username} in ${guild.name}` : args[2].username,
                     timeout: Math.min(Math.max(args[1].content.split(" ").length * 0.5e3, 4e3), 10e3),
-                    content: this.parse(args[1].content, guild),
+                    content: React.createElement(MessageContent, {
+                      message: {
+                        ...args[1],
+                        isEdited: () => false,
+                        hasFlag: () => false // somehow having theese be functions that return false makes discord not crash????????????
+                      },
+                      content: parser(args[1].content)
+                    }),
                     buttons: [ {
                         text: `Jump to ${guild ? `#${args[0].name}` : "Direct Messages"}`,
                         look: "outlined",
@@ -55,12 +60,5 @@ module.exports = class InAppNotifciations extends Plugin {
     pluginWillUnload() {
         uninject("ian");
         powercord.api.settings.unregisterSettings(`ian-settings`);
-    }
-
-    parse(content, guild) {
-        return content
-        .replace(/<@!?(\d+)>/g, (_, p) => `@${getUser(p).username}`)
-        .replace(/<#(\d+)>/g, (_, p) => `#${getChannel(p).name}`)
-        .replace(/<@&(\d+)>/g, (_, p) => `@${guild.roles[p].name}`);
     }
 };


### PR DESCRIPTION
## Decription
Uses Discord's ``MessageContent`` React component to parse markdown the same way messages do, making usernames clickable and emojis show up
## Testing Methods
Dm'ed myself from an alt and send messages pinging myself in my server.
Tested basic markdown (italic, bold, codeblocks), mentions, and emojis.
![Image](https://img.bigdumb.gq/ss/21s7cA.png)

## Check the boxes
- [x] I tested the features I added.
- [x] I followed the established style and used 4 space tabs
- [x] I made sure this doesnt break any of [Powercord's Plugin Guildelines](https://github.com/powercord-community/guidelines)
- [ ] Don't check this box, I want to make sure you actually read them.
