### PR TITLE
make blocking desktop notifs work, also misc fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { getModule, React } = require("powercord/webpack");
 const { inject, uninject } = require("powercord/injector");
 const { Plugin } = require("powercord/entities");
 const { getGuild } = getModule(["getGuild"], false);
+const shouldDisplayNotifications = getModule(["shouldDisplayNotifications"], false);
 const parser = getModule(["parse", "parseTopic"], false).parse;
 const MessageContent = getModule(m => m.type && m.type.displayName == "MessageContent", false);
 const Settings = require("./Settings");
@@ -20,14 +21,14 @@ module.exports = class InAppNotifciations extends Plugin {
             const show = getModule(["makeTextChatNotification"], false);
             const transition = getModule(["transitionTo"], false);
 
-            inject( "ian", show, "makeTextChatNotification", (args, other) => {
+            inject( "ian", show, "makeTextChatNotification", (args) => {
                 console.log(args);
                 const toast = (Math.random().toString(36) + Date.now()).substring(2, 7);
                 const guild = getGuild(args[0].guild_id);
 
                 if (!args[1].content.match(new RegExp(`<(@!?|#|@&)?(${getModule(["getCurrentUser"], false).getCurrentUser().id})>`,`g`))
                     && onPing)
-                    return;
+                    return args;
 
                 powercord.api.notices.sendToast(toast, {
                     header: guild ? `${args[2].username} in ${guild.name}` : args[2].username,
@@ -51,11 +52,15 @@ module.exports = class InAppNotifciations extends Plugin {
                         size: "small",
                     } ]
                 });
-                if (document.hasFocus())
-                    other = {body: "", name: "", icon: ""};
-                    
-                return other;
-            }, false );
+
+                return args;
+            }, true );
+            inject( "ian-desktop-blocker", shouldDisplayNotifications, "shouldDisplayNotifications", (args) => {
+                if (document.hasFocus()) {
+                    return false;
+                }
+                return args;
+            }, true)
         } catch (error) {
             console.error(`There seems to have been a problem with the in app notifications. Please report this to the developer.\n\n${error}`);
         }
@@ -63,6 +68,7 @@ module.exports = class InAppNotifciations extends Plugin {
 
     pluginWillUnload() {
         uninject("ian");
+        uninject("ian-desktop-blocker");
         powercord.api.settings.unregisterSettings(`ian-settings`);
     }
 };


### PR DESCRIPTION
## Decription
Injects into ``shouldDisplayNotifications`` to prevent desktop notifications from showing when Discord's window is focused. Also makes only show on ping not potentially cause errors by still returning args.
## Testing Methods
Checked that desktop notifs show when window is unfocused and hide when focused.
## Check the boxes
- [x] I tested the features I added.
- [x] I followed the established style and used 4 space tabs
- [x] I made sure this doesnt break any of [Powercord's Plugin Guildelines](https://github.com/powercord-community/guidelines)
- [ ] Don't check this box, I want to make sure you actually read them.
